### PR TITLE
Fix confusing with frozen slack account

### DIFF
--- a/chainer_slack_report/slack_report.py
+++ b/chainer_slack_report/slack_report.py
@@ -54,7 +54,7 @@ def _name_to_mention(access_token, names):
         if not r:
             return []
         user_ids = {**user_ids,
-                    **{m['name']: m['id']
+                    **{m['profile']['display_name']: m['id']
                        for m in r['members'] if not m['deleted']}}
         cursor = r['response_metadata']['next_cursor']
         if not cursor:

--- a/chainer_slack_report/slack_report.py
+++ b/chainer_slack_report/slack_report.py
@@ -53,7 +53,9 @@ def _name_to_mention(access_token, names):
         r = _slack_request('users.list', 'get', params)
         if not r:
             return []
-        user_ids = {**user_ids, **{m['name']: m['id'] for m in r['members']}}
+        user_ids = {**user_ids,
+                    **{m['name']: m['id']
+                       for m in r['members'] if not m['deleted']}}
         cursor = r['response_metadata']['next_cursor']
         if not cursor:
             break


### PR DESCRIPTION
The current slack notification (mention after the training finishes) had two problems.

* In case there are multiple users that have the same display name
    * This happens when only one user is active and others are already deactivated
* Display Name vs Name
    * The current implementation looked at only "name"
    * But on Slack client, when sending a mension we use display name instead
        * So it is natural to use display name in chainer_slack_report too

This PR fixes both of them.

TODO: There is a case where display name becomes empty, although we can send mention using (apparently) real_name? Need to check